### PR TITLE
Compiling empty jar in scala_client compilation if model is empty.

### DIFF
--- a/src/com/dslplatform/compiler/client/parameters/build/CompileScalaClient.java
+++ b/src/com/dslplatform/compiler/client/parameters/build/CompileScalaClient.java
@@ -10,7 +10,7 @@ public class CompileScalaClient implements BuildAction {
 
 	@Override
 	public boolean check(final Context context) throws ExitException {
-		return Download.checkJars(context, "Scala client", "scala-client", "scala_client", "dsl-client-scala-http_2.10");
+		return Download.checkJars(context, "Scala client", "scala-client", "scala_client", "dsl-client-scala_2.10");
 	}
 
 	@Override


### PR DESCRIPTION
Otherwise scala compilation fails since there is no generated code.

Renamed scala_client version to be downloaded from Sonatype.
