### PR TITLE
Rename 'php' target to 'php_client'

### DIFF
--- a/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
@@ -48,7 +48,7 @@ public enum Targets implements CompileParameter, ParameterParser {
 		DOTNET_CLIENT("dotnet_client", ".NET client", "CSharpClient", ".cs", new CompileCsClient(".NET client", "client", "dotnet_client", "./ClientModel.dll", DOTNET_CLIENT_DEPENDENCIES, false), false),
 		DOTNET_PORTABLE("dotnet_portable", ".NET portable", "CSharpPortable", ".cs", new CompileCsClient(".NET portable", "portable", "dotnet_portable", "./PortableModel.dll", new String[0], false), false),
 		DOTNET_WPF("wpf", ".NET WPF GUI", "Wpf", ".cs", new CompileCsClient(".NET WPF GUI", "wpf", "dotnet_wpf", "./WpfModel.dll", DOTNET_WPF_DEPENDENCIES, true), false),
-		PHP("php", "PHP client", "Php", ".php", new PrepareSources("PHP", "php", "Generated-PHP"), true),
+		PHP("php_client", "PHP client", "Php", ".php", new PrepareSources("PHP", "php_client", "Generated-PHP"), true),
 		PHP_UI("php_ui", "PHP UI client", "PhpUI", "", new PreparePhpUI("PHP UI", "php_ui", "Generated-PHP-UI"), true),
 		SCALA_CLIENT("scala_client", "Scala client", "ScalaClient", ".scala", new CompileScalaClient(), false),
 		SCALA_SERVER("scala_server", "Scala server", "ScalaServer", ".scala", new PrepareSources("Scala server", "scala_server", "Generated-Scala-Server"), true);


### PR DESCRIPTION
fixes using offline compiler (reports unknown target 'php')
other targets suffixed '_client'