### PR TITLE
Remove disallowed chars from file path

### DIFF
--- a/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
@@ -228,8 +228,9 @@ public enum Targets implements CompileParameter, ParameterParser {
 			final Context context,
 			final String temp,
 			final boolean escapeName,
-			final String name,
+			final String fileName,
 			final String content) throws ExitException, IOException {
+		final String name = fileName.replaceAll("[\\/:*?\"<>|^]", "_");
 		final String nameOnly = name.contains(".") ? name.substring(0, name.lastIndexOf('.')) : name;
 		final File file = escapeName
 				? new File(temp, nameOnly.replace(".", "/") + name.substring(nameOnly.length()))

--- a/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/Targets.java
@@ -230,7 +230,7 @@ public enum Targets implements CompileParameter, ParameterParser {
 			final boolean escapeName,
 			final String fileName,
 			final String content) throws ExitException, IOException {
-		final String name = fileName.replaceAll("[\\/:*?\"<>|^]", "_");
+		final String name = fileName.replace(':', '_');
 		final String nameOnly = name.contains(".") ? name.substring(0, name.lastIndexOf('.')) : name;
 		final File file = escapeName
 				? new File(temp, nameOnly.replace(".", "/") + name.substring(nameOnly.length()))


### PR DESCRIPTION
Sanitize path name by replacing all disallowed characters with underscores (problem with namespaces containing 'global::' on windows).