### PR TITLE
UTF-8 encoding on streams, SQL migration timing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.dslplatform</groupId>
   <artifactId>dsl-clc</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0</version>
+  <version>1.4.1-SNAPSHOT</version>
   <name>DSL Platform - Compiler Command-Line Client</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/dslplatform/compiler/client/parameters/PostgresConnection.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/PostgresConnection.java
@@ -120,7 +120,10 @@ public enum PostgresConnection implements CompileParameter {
 			throw new ExitException();
 		}
 		try {
+			final long startAt = System.currentTimeMillis();
 			stmt.execute(sql);
+			final long endAt = System.currentTimeMillis();
+			context.log("Script executed in " + (endAt - startAt) + "ms");
 			stmt.close();
 			conn.close();
 		} catch (SQLException ex) {

--- a/src/main/resources/com/dslplatform/compiler/client/dsl-clc.properties
+++ b/src/main/resources/com/dslplatform/compiler/client/dsl-clc.properties
@@ -1,2 +1,2 @@
-version=1.3.0
-date=2015-04-18
+version=1.4.1-SNAPSHOT
+date=2015-08-28


### PR DESCRIPTION
Added time measurement to SQL script execution.
Reading a stream assumes UTF-8 encoding.
Close streams in finally blocks.