### PR TITLE
Perform javac error check via exit code instead of stderr emptiness

### DIFF
--- a/src/main/java/com/dslplatform/compiler/client/Utils.java
+++ b/src/main/java/com/dslplatform/compiler/client/Utils.java
@@ -302,7 +302,7 @@ public abstract class Utils {
 			final Process compilation = pb.start();
 			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), context);
 			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), context);
-			compilation.waitFor();
+			final int exitCode = compilation.waitFor();
 			result.join();
 			error.join();
 			if (result.exception != null) {
@@ -311,7 +311,7 @@ public abstract class Utils {
 			if (error.exception != null) {
 				return Either.fail(error.exception);
 			}
-			return Either.success(new CommandResult(result.output.toString(), error.output.toString(), compilation.exitValue()));
+			return Either.success(new CommandResult(result.output.toString(), error.output.toString(), exitCode));
 		} catch (IOException ex) {
 			return Either.fail(ex);
 		} catch (InterruptedException ex) {

--- a/src/main/java/com/dslplatform/compiler/client/parameters/build/JavaCompilation.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/build/JavaCompilation.java
@@ -55,7 +55,8 @@ class JavaCompilation {
 
 		final List<String> javacArguments = new ArrayList<String>();
 		javacArguments.add("-encoding");
-		javacArguments.add("UTF8");
+		javacArguments.add("UTF-8");
+		javacArguments.add("-Xlint:none"); // notices still get emitted to the stderr
 		javacArguments.add("-d");
 		javacArguments.add("compile-" + name);
 		javacArguments.add("-cp");
@@ -88,8 +89,12 @@ class JavaCompilation {
 			return Either.fail(execCompile.whyNot());
 		}
 		final Utils.CommandResult compilation = execCompile.get();
-		if (compilation.error.length() > 0) {
-			return Either.fail(compilation.error);
+		if (compilation.exitCode != 0) {
+			if (compilation.error.length() > 0) {
+				return Either.fail(compilation.error);
+			} else {
+				return Either.fail("Non-zero exit code: " + compilation.exitCode);
+			}
 		}
 		if (compilation.output.contains("error")) {
 			final StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Even with -nowarn (aka -Xlint:none) javac will still produce notices about all kinds of warnings, e.g.
    
    Note: Some input files use unchecked or unsafe operations.
    Note: Recompile with -Xlint:unchecked for details.

These cannot be disabled via a javac flag so the previous check for errors is not satisfactory.