### PR TITLE
Added System.exit to Main method.

### DIFF
--- a/src/main/java/com/dslplatform/compiler/client/Main.java
+++ b/src/main/java/com/dslplatform/compiler/client/Main.java
@@ -11,13 +11,11 @@ import java.net.URLClassLoader;
 import java.util.*;
 
 public class Main {
-
 	public static void main(final String[] args) {
 		final Context context = new Context();
 		final List<CompileParameter> parameters = initializeParameters(context, ".");
-		if (parse(args, context, parameters)) {
-			processContext(context, parameters);
-		}
+		final int returnCode = parse(args, context, parameters) ? (processContext(context, parameters) ? 0 : 1) : 2;
+		System.exit(returnCode);
 	}
 
 	static List<CompileParameter> initializeParameters(final Context context, final String path) {

--- a/src/main/java/com/dslplatform/compiler/client/parameters/PostgresConnection.java
+++ b/src/main/java/com/dslplatform/compiler/client/parameters/PostgresConnection.java
@@ -110,13 +110,14 @@ public enum PostgresConnection implements CompileParameter {
 		final String connectionString = "jdbc:postgresql://" + context.get(INSTANCE);
 
 		// if protocolVersion is present in the connectionString, it will take precedence
-		final Properties defaultParams = new Properties();
-		defaultParams.put("protocolVersion", "2");
+		// final Properties defaultParams = new Properties();
+		// defaultParams.put("protocolVersion", "2");
 
 		Connection conn;
 		Statement stmt;
 		try {
-			conn = DriverManager.getConnection(connectionString, defaultParams);
+			// conn = DriverManager.getConnection(connectionString, defaultParams);
+			conn = DriverManager.getConnection(connectionString);
 			stmt = conn.createStatement();
 		} catch (SQLException e) {
 			context.error("Error opening connection to " + connectionString);

--- a/src/main/resources/com/dslplatform/compiler/client/dsl-clc.properties
+++ b/src/main/resources/com/dslplatform/compiler/client/dsl-clc.properties
@@ -1,2 +1,2 @@
-version=1.4.2-SNAPSHOT
-date=2015-09-06
+version=1.5.0
+date=2015-11-04


### PR DESCRIPTION
Returns 0 on success, 2 on parse error and 1 otherwise.
Disabled setting of protocolVersion=2 by default as it doesn't work with PostgreSQL 9.5+ (no support for autocommit).