### PR TITLE
Changed location dsl-compiler from the Temp folder to %localappdata%

### DIFF
--- a/VisualStudioPlugin/Compiler.cs
+++ b/VisualStudioPlugin/Compiler.cs
@@ -97,7 +97,7 @@ namespace DDDLanguage
 		{
 			get
 			{
-				var path = Path.Combine(Path.GetTempPath(), "DSLPlatform");
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DSLPlatform");
 				if (!Directory.Exists(path))
 					Directory.CreateDirectory(path);
 				return path;


### PR DESCRIPTION
Changed the location for the dsl-compiler.exe from the Temp folder to the %localappdata% folder because the Temp folder might be too volatile (for example a RAM Disk based Temp folder is empty after a reboot and then user has to download the dsl-compiler daily)