### PR TITLE
Fix parsing/compile error when project name ends in .dsl

### DIFF
--- a/VisualStudioPlugin/Gui/ServerActions.cs
+++ b/VisualStudioPlugin/Gui/ServerActions.cs
@@ -177,8 +177,9 @@ namespace DDDLanguage
 		{
 			foreach (ProjectItem pi in items)
 			{
-				if (pi.Name.EndsWith(".dsl", StringComparison.InvariantCultureIgnoreCase)
+				if ((pi.Name.EndsWith(".dsl", StringComparison.InvariantCultureIgnoreCase)
 					|| pi.Name.EndsWith(".ddd", StringComparison.InvariantCultureIgnoreCase))
+					&& pi.FileNames[1] != null)
 				{
 					var path = pi.FileNames[1];
 					var name = path.StartsWith(LibraryInfo.BasePath) ? path.Substring(LibraryInfo.BasePath.Length) : path;
@@ -207,8 +208,9 @@ namespace DDDLanguage
 		{
 			foreach (ProjectItem pi in items)
 			{
-				if (pi.Name.EndsWith(".dsl", StringComparison.InvariantCultureIgnoreCase)
+				if ((pi.Name.EndsWith(".dsl", StringComparison.InvariantCultureIgnoreCase)
 					|| pi.Name.EndsWith(".ddd", StringComparison.InvariantCultureIgnoreCase))
+					&& pi.FileNames[1] != null)
 				{
 					dsls.Add(pi.FileNames[1]);
 				}


### PR DESCRIPTION
Fix for these errors when the project name end in .dsl

![image](https://user-images.githubusercontent.com/11263864/32149838-bf1751a0-bd5e-11e7-988e-b9e9ea1492ad.png)
![image](https://user-images.githubusercontent.com/11263864/32149843-d5717750-bd5e-11e7-958e-f9a3c7b49003.png)
