### PR TITLE
sbt plug-in: Remove error message

### DIFF
--- a/SbtPlugin/src/main/scala/com/dslplatform/sbt/SbtDslPlatformPlugin.scala
+++ b/SbtPlugin/src/main/scala/com/dslplatform/sbt/SbtDslPlatformPlugin.scala
@@ -111,10 +111,8 @@ object SbtDslPlatformPlugin extends AutoPlugin {
       val cacheDirectory = streams.value.cacheDirectory
       val settingsFile   = createCompilerSettingsFingerprint().value
 
-      if (dslSources.value.isEmpty) {
-        logger.error(s"$scope: dslSources must be set")
-        Seq()
-      } else {
+      if (dslSources.value.isEmpty) Seq()
+      else {
         val cached = FileFunction.cached(
           cacheDirectory / "dsl-generate",
           inStyle = FilesInfo.hash,


### PR DESCRIPTION
Not every sub-project that uses the plug-in is required to have DSL
sources. Some may only create resource files. The error message is
therefore misleading.