### PR TITLE
sbt plug-in: Evaluating `dependencyClasspath` triggers compilation

### DIFF
--- a/SbtPlugin/build.sbt
+++ b/SbtPlugin/build.sbt
@@ -3,7 +3,7 @@ sbtPlugin := true
 organization := "com.dslplatform"
 name := "sbt-dsl-platform"
 
-version := "0.7.6"
+version := "0.7.7"
 
 libraryDependencies ++= Seq(
   "com.dslplatform" % "dsl-clc" % "1.9.6",

--- a/SbtPlugin/src/main/scala/com/dslplatform/sbt/SbtDslPlatformPlugin.scala
+++ b/SbtPlugin/src/main/scala/com/dslplatform/sbt/SbtDslPlatformPlugin.scala
@@ -117,7 +117,7 @@ object SbtDslPlatformPlugin extends AutoPlugin {
     dslGenerate := {
       val logger = streams.value.log
 
-      val depClassPath   = dependencyClasspath.value
+      val depClassPath   = managedClasspath.value
       val tempFolder     = dslTempFolder.value
       val cacheDirectory = streams.value.cacheDirectory
       val settings       = dslSettings.value


### PR DESCRIPTION
Presently, the source generation performs a compilation run due to
the use of `dependencyClasspath`. Avoid this by using
`managedClasspath` instead.

Background: https://gitter.im/scalacenter/bloop?at=5bed89d621387234050f38b4