### PR TITLE
dslResource: Sort classes by name

### DIFF
--- a/SbtPlugin/src/main/scala/com/dslplatform/sbt/Actions.scala
+++ b/SbtPlugin/src/main/scala/com/dslplatform/sbt/Actions.scala
@@ -493,7 +493,7 @@ object Actions {
             logger.error(s"Error creating folder: ${file.getParentFile.getAbsolutePath}")
           }
           val fos = new FileOutputStream(file)
-          fos.write(vals.mkString("\n").getBytes("UTF-8"))
+          fos.write(vals.sorted.mkString("\n").getBytes("UTF-8"))
           fos.close()
         }
       }


### PR DESCRIPTION
Ensure that dslResource class names have the same ordering regardless
of how the files are physically stored on the disk.