### PR TITLE
Fix encoding problems when talking to compiler on Windows

### DIFF
--- a/CommandLineClient/pom.xml
+++ b/CommandLineClient/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.dslplatform</groupId>
 	<artifactId>dsl-clc</artifactId>
 	<packaging>jar</packaging>
-	<version>1.9.8</version>
+	<version>1.9.9</version>
 	<name>DSL Platform - Compiler Command-Line Client</name>
 	<url>https://github.com/ngs-doo/dsl-compiler-client</url>
 	<description>Command line client for interaction with DSL Platform compiler (https://dsl-platform.com)</description>

--- a/CommandLineClient/pom.xml
+++ b/CommandLineClient/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.dslplatform</groupId>
 	<artifactId>dsl-clc</artifactId>
 	<packaging>jar</packaging>
-	<version>1.9.9</version>
+	<version>1.9.8</version>
 	<name>DSL Platform - Compiler Command-Line Client</name>
 	<url>https://github.com/ngs-doo/dsl-compiler-client</url>
 	<description>Command line client for interaction with DSL Platform compiler (https://dsl-platform.com)</description>

--- a/CommandLineClient/src/main/java/com/dslplatform/compiler/client/Utils.java
+++ b/CommandLineClient/src/main/java/com/dslplatform/compiler/client/Utils.java
@@ -262,15 +262,7 @@ public abstract class Utils {
 		return testCommand(context, command, contains, Collections.<String>emptyList());
 	}
 
-	public static boolean testCommand(final Context context, final String command, final String contains, final Charset charset) {
-		return testCommand(context, command, contains, Collections.<String>emptyList(), charset);
-	}
-
 	public static boolean testCommand(final Context context, final String command, final String contains, final List<String> arguments) {
-		return testCommand(context, command, contains, arguments, Charset.defaultCharset());
-	}
-
-	public static boolean testCommand(final Context context, final String command, final String contains, final List<String> arguments, final Charset charset) {
 		try {
 			final List<String> commandAndArgs = new ArrayList<String>();
 			commandAndArgs.add(command);
@@ -279,8 +271,8 @@ public abstract class Utils {
 			pb.environment().put("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
 			logCommand(context, pb);
 			final Process compilation = pb.start();
-			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), null, charset);
-			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), null, charset);
+			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), null, Charset.defaultCharset());
+			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), null, Charset.defaultCharset());
 			compilation.waitFor();
 			result.join();
 			error.join();

--- a/CommandLineClient/src/main/java/com/dslplatform/compiler/client/Utils.java
+++ b/CommandLineClient/src/main/java/com/dslplatform/compiler/client/Utils.java
@@ -6,6 +6,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.*;
 import java.net.*;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -187,8 +188,8 @@ public abstract class Utils {
 		private final StringBuilder output = new StringBuilder();
 		private IOException exception;
 
-		private ConsumeStream(final InputStream stream, final Context context) {
-			this.reader = new BufferedReader(new InputStreamReader(stream));
+		private ConsumeStream(final InputStream stream, final Context context, final Charset charset) {
+			this.reader = new BufferedReader(new InputStreamReader(stream, charset));
 			this.context = context;
 		}
 
@@ -197,11 +198,11 @@ public abstract class Utils {
 			this.context = null;
 		}
 
-		static ConsumeStream start(final InputStream stream, final Context context) {
+		static ConsumeStream start(final InputStream stream, final Context context, final Charset charset) {
 			if (stream == null) {
 				return new ConsumeStream();
 			}
-			final ConsumeStream cs = new ConsumeStream(stream, context);
+			final ConsumeStream cs = new ConsumeStream(stream, context, charset);
 			cs.start();
 			return cs;
 		}
@@ -238,18 +239,18 @@ public abstract class Utils {
 
 	public static Either<String> findCommand(final Context context, final String path, final String name, final String contains) {
 		final String simple = path != null ? new File(path, name).getAbsolutePath() : name;
-		if (testCommand(context, simple, contains, new ArrayList<String>())) {
+		if (testCommand(context, simple, contains)) {
 			context.log("Found " + name + " in " + simple);
 			return Either.success(simple);
 		}
 		if (isWindows()) {
 			final String bat = path != null ? new File(path, name + ".bat").getAbsolutePath() : name + ".bat";
-			if (testCommand(context, bat, contains, new ArrayList<String>())) {
+			if (testCommand(context, bat, contains)) {
 				context.log("Found " + name + " in " + bat);
 				return Either.success(bat);
 			}
 			final String cmd = path != null ? new File(path, name + ".cmd").getAbsolutePath() : name + ".cmd";
-			if (testCommand(context, cmd, contains, new ArrayList<String>())) {
+			if (testCommand(context, cmd, contains)) {
 				context.log("Found " + name + " in " + cmd);
 				return Either.success(cmd);
 			}
@@ -258,10 +259,18 @@ public abstract class Utils {
 	}
 
 	public static boolean testCommand(final Context context, final String command, final String contains) {
-		return testCommand(context, command, contains, new ArrayList<String>());
+		return testCommand(context, command, contains, Collections.<String>emptyList());
+	}
+
+	public static boolean testCommand(final Context context, final String command, final String contains, final Charset charset) {
+		return testCommand(context, command, contains, Collections.<String>emptyList(), charset);
 	}
 
 	public static boolean testCommand(final Context context, final String command, final String contains, final List<String> arguments) {
+		return testCommand(context, command, contains, arguments, Charset.defaultCharset());
+	}
+
+	public static boolean testCommand(final Context context, final String command, final String contains, final List<String> arguments, final Charset charset) {
 		try {
 			final List<String> commandAndArgs = new ArrayList<String>();
 			commandAndArgs.add(command);
@@ -270,8 +279,8 @@ public abstract class Utils {
 			pb.environment().put("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
 			logCommand(context, pb);
 			final Process compilation = pb.start();
-			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), null);
-			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), null);
+			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), null, charset);
+			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), null, charset);
 			compilation.waitFor();
 			result.join();
 			error.join();
@@ -286,6 +295,10 @@ public abstract class Utils {
 	}
 
 	public static Either<CommandResult> runCommand(final Context context, final String command, final File path, final List<String> arguments) {
+		return runCommand(context, command, path, arguments, Charset.defaultCharset());
+	}
+
+	public static Either<CommandResult> runCommand(final Context context, final String command, final File path, final List<String> arguments, final Charset charset) {
 		try {
 			final List<String> commandAndArgs = new ArrayList<String>();
 			commandAndArgs.add(command);
@@ -297,8 +310,8 @@ public abstract class Utils {
 			}
 			logCommand(context, pb);
 			final Process compilation = pb.start();
-			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), context);
-			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), context);
+			final ConsumeStream result = ConsumeStream.start(compilation.getInputStream(), context, charset);
+			final ConsumeStream error = ConsumeStream.start(compilation.getErrorStream(), context, charset);
 			final int exitCode = compilation.waitFor();
 			result.join();
 			error.join();

--- a/CommandLineClient/src/main/java/com/dslplatform/compiler/client/parameters/DslCompiler.java
+++ b/CommandLineClient/src/main/java/com/dslplatform/compiler/client/parameters/DslCompiler.java
@@ -793,11 +793,11 @@ public enum DslCompiler implements CompileParameter, ParameterParser {
 
 	private static boolean testCompiler(final Context context, final File path) throws ExitException {
 		if (Utils.isWindows()) {
-			return Utils.testCommand(context, path.getAbsolutePath(), "DSL Platform", Charset.forName("UTF-8"));
+			return Utils.testCommand(context, path.getAbsolutePath(), "DSL Platform");
 		} else {
 			final Either<String> mono = Mono.findMono(context);
 			if (mono.isSuccess()) {
-				return Utils.testCommand(context, mono.get(), "DSL Platform", Collections.singletonList(path.getAbsolutePath()), Charset.forName("UTF-8"));
+				return Utils.testCommand(context, mono.get(), "DSL Platform", Collections.singletonList(path.getAbsolutePath()));
 			} else {
 				context.error("Mono is required to run DSL compiler. Mono not detected or specified.");
 				throw new ExitException();

--- a/CommandLineClient/src/main/java/com/dslplatform/compiler/client/parameters/DslCompiler.java
+++ b/CommandLineClient/src/main/java/com/dslplatform/compiler/client/parameters/DslCompiler.java
@@ -546,7 +546,7 @@ public enum DslCompiler implements CompileParameter, ParameterParser {
 			final List<String> arguments) throws ExitException {
 		Either<Utils.CommandResult> result;
 		if (Utils.isWindows()) {
-			result = Utils.runCommand(context, compiler.getAbsolutePath(), compiler.getParentFile(), arguments);
+			result = Utils.runCommand(context, compiler.getAbsolutePath(), compiler.getParentFile(), arguments, Charset.forName("UTF-8"));
 		} else {
 			final Either<String> mono = Mono.findMono(context);
 			if (mono.isSuccess()) {
@@ -560,7 +560,7 @@ public enum DslCompiler implements CompileParameter, ParameterParser {
 					} catch (InterruptedException ignore) {
 						throw new ExitException();
 					}
-					result = Utils.runCommand(context, mono.get(), compiler.getParentFile(), arguments);
+					result = Utils.runCommand(context, mono.get(), compiler.getParentFile(), arguments, Charset.forName("UTF-8"));
 				}
 			} else {
 				context.error("Mono is required to run DSL compiler. Mono not detected or specified.");
@@ -793,11 +793,11 @@ public enum DslCompiler implements CompileParameter, ParameterParser {
 
 	private static boolean testCompiler(final Context context, final File path) throws ExitException {
 		if (Utils.isWindows()) {
-			return Utils.testCommand(context, path.getAbsolutePath(), "DSL Platform");
+			return Utils.testCommand(context, path.getAbsolutePath(), "DSL Platform", Charset.forName("UTF-8"));
 		} else {
 			final Either<String> mono = Mono.findMono(context);
 			if (mono.isSuccess()) {
-				return Utils.testCommand(context, mono.get(), "DSL Platform", Collections.singletonList(path.getAbsolutePath()));
+				return Utils.testCommand(context, mono.get(), "DSL Platform", Collections.singletonList(path.getAbsolutePath()), Charset.forName("UTF-8"));
 			} else {
 				context.error("Mono is required to run DSL compiler. Mono not detected or specified.");
 				throw new ExitException();


### PR DESCRIPTION
Override default platform encoding to match compiler output (UTF-8)