### PR TITLE
Use canonicalFile resolution for current working directory

### DIFF
--- a/SbtPlugin/build.sbt
+++ b/SbtPlugin/build.sbt
@@ -3,10 +3,10 @@ sbtPlugin := true
 organization := "com.dslplatform"
 name := "sbt-dsl-platform"
 
-version := "0.7.9"
+version := "0.7.10"
 
 libraryDependencies ++= Seq(
-  "com.dslplatform" % "dsl-clc" % "1.9.7",
+  "com.dslplatform" % "dsl-clc" % "1.9.8",
   "org.clapper" %% "classutil" % "1.1.2"
 )
 

--- a/SbtPlugin/src/main/scala/com/dslplatform/sbt/Actions.scala
+++ b/SbtPlugin/src/main/scala/com/dslplatform/sbt/Actions.scala
@@ -197,7 +197,7 @@ object Actions {
     customSettings: Seq[String] = Nil,
     classPath: Classpath,
     latest: Boolean = true): Seq[File] = {
-    val cwd = Paths.get("").toAbsolutePath.toString
+    val cwd = new File("").getCanonicalPath
     if (cwd == output.getCanonicalPath || !output.getCanonicalPath.startsWith(cwd)) {
       logger.error("Output path must be at least one level below working directory")
       return Seq.empty


### PR DESCRIPTION
This resolves issue when the same path may be resolved differently if
using .getAbsolutePath and .getCanonicalPath on Windows (d:\ vs D:\)

Bump dsl-clc to 1.9.8 in SbtPlugin
Bump version of SbtPlugin to 0.7.10