### PR TITLE
Fix VS 2022 17.12+ load failure (0x80049283) by deferring ToolWindow creation until after package load

### DIFF
--- a/VisualStudioPlugin/Shared/Gui/ToolPresenter.cs
+++ b/VisualStudioPlugin/Shared/Gui/ToolPresenter.cs
@@ -450,16 +450,17 @@ namespace DSLPlatform
 			LastTool.Content = new AboutControl { DataContext = this };
 		}
 
-		public void SetupBasePath()
+		public void SetupBasePath(EnvDTE.DTE dte)
 		{
-			LibraryInfo.BasePath = DTE.Solution != null ? Path.GetDirectoryName(DTE.Solution.FullName) + Path.DirectorySeparatorChar : null;
+			Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+			LibraryInfo.BasePath = dte?.Solution != null ? Path.GetDirectoryName(dte.Solution.FullName) + Path.DirectorySeparatorChar : null;
 		}
 
 		public void PrepareWindow()
 		{
 			Message = null;
 			ChangeMessage();
-			SetupBasePath();
+			SetupBasePath(DTE);
 
 			ResetConfiguration();
 			Message = null;


### PR DESCRIPTION
The "[New restrictions on package loading](https://devblogs.microsoft.com/visualstudio/new-restrictions-on-package-loading/)" change detects cyclic package-load requests.
Creating the ToolWindow inside `Initialize*/InitializeAsync` triggered such a cycle, causing VS_E_CYCLICPACKAGELOAD / HRESULT 0x80049283 and preventing the extension from loading.

* Removed eager `FindToolWindow*` call from `Initialize*/InitializeAsync`.
* Added cached fields `window` and `dte`.
* Introduced `EnsureToolWindow` / `EnsureToolWindowAsync` helpers that
  - switch to the UI thread [VSTHRD109](https://microsoft.github.io/vs-threading/analyzers/VSTHRD109.html),
  - lazily create the window with `FindToolWindow*`,
  - initialise `Presenter` and call `Presenter.PrepareWindow()`.
* Hooked `SolutionEvents.Opened` to create & prepare the window only after the solution is fully loaded.
* Adjusted `Presenter.SetupBasePath` call to accept `dte`.

Tested:
1. Open a solution with the DSL Platform window closed View the DSL Platform window and it should be populated
2. Close a solution while the DSL Platform window is focused The DSL Platform window contents should clear
3. Open a solution The DSL Platform window should be populated
4. Set the focus on the Solution Explorer window and close Visual Studio
5. Open Visual Studio, open a solution and focus theDSL Platform window and it should be populated